### PR TITLE
Use turn-on-font-lock-if-desired instead of turn-on-font-lock.

### DIFF
--- a/tool-support/emacs/scala-mode.el
+++ b/tool-support/emacs/scala-mode.el
@@ -197,7 +197,7 @@ When started, run `scala-mode-hook'.
    )
 
   (use-local-map scala-mode-map)
-  (turn-on-font-lock)
+  (turn-on-font-lock-if-desired)
   (scala-mode-feature-install)
   )
 


### PR DESCRIPTION
This respects user settings that disable font-lock mode.  I always have it disabled because I'm low vision.  Sometimes I think I must be the only person who disables it, but then why would we have the -if-desired function?